### PR TITLE
Sega-CD Final Fight OST CPS1 Support

### DIFF
--- a/src/drivers/cps1.c
+++ b/src/drivers/cps1.c
@@ -25,6 +25,68 @@ void punisher_decode(void);
 void slammast_decode(void);
 
 
+const char *const ffight_sample_names[] =
+{
+	"*ffight",
+	"track02-01",
+	"track02-02",
+	"track03-01",
+	"track03-02",
+	"track04-01",
+	"track04-02",
+	"track05-01",
+	"track05-02",
+	"track06-01",
+	"track06-02",
+	"track07-01",
+	"track07-02",
+	"track08-01",
+	"track08-02",
+	"track09-01",
+	"track09-02",
+	"track10-01",
+	"track10-02",
+	"track11-01",
+	"track11-02",
+	"track12-01",
+	"track12-02",
+	"track13-01",
+	"track13-02",
+	"track14-01",
+	"track14-02",
+	"track15-01",
+	"track15-02",
+	"track16-01",
+	"track16-02",
+	"track17-01",
+	"track17-02",
+	"track18-01",
+	"track18-02",
+	"track19-01",
+	"track19-02",
+	"track20-01",
+	"track20-02",
+	"track21-01",
+	"track21-02",
+	"track22-01",
+	"track22-02",
+	"track23-01",
+	"track23-02",
+	"track24-01",
+	"track24-02",
+	"track25-01",
+	"track25-02",
+	"track26-01",
+	"track26-02",
+	0
+};
+
+static struct Samplesinterface ff_samples =
+{
+	2,	// 2 channels
+	100, // volume
+	ffight_sample_names
+};
 
 static READ16_HANDLER( cps1_input_r )
 {
@@ -95,8 +157,201 @@ static READ_HANDLER( cps1_snd_fade_timer_r )
 
 static WRITE16_HANDLER( cps1_sound_command_w )
 {
-	if (ACCESSING_LSB)
-		soundlatch_w(0,data & 0xff);
+	// Debug.
+	/*
+	if (data != 0xff) {
+		printf("%X\n", data);
+	}
+	*/
+	
+	// We are playing Final Fight. Let's use the samples.
+	if(ff_playing_final_fight == true) {
+		switch (data) {
+			// stage 1 upper level music
+			case 0x40:
+				// Play the left channel.
+				sample_start(0, 0, 1);
+
+				// Play the right channel.
+				sample_start(1, 1, 1);
+
+				break;
+			// stage #1: basement
+			case 0x41:
+				sample_start(0, 2, 1);
+				sample_start(1, 3, 1);
+
+				break;
+			// stage #2: subway intro
+			case 0x42:
+				// play the normal version of the song unless playAlternateSong is true
+				if (ff_play_alternate_song == false) {
+					sample_start(0, 4, 1);
+					sample_start(1, 5, 1);
+				}
+				else {
+					sample_start(0, 40, 1);
+					sample_start(1, 41, 1);
+				}
+				
+				break;
+			// stage #2 exiting subway/alley
+			case 0x43:
+				sample_start(0, 6, 1);
+				sample_start(1, 7, 1);
+
+				break;
+			// double andore cage fight music
+			case 0x44:
+				sample_start(0, 8, 1);
+				sample_start(1, 9, 1);
+
+				break;
+			// bay area sea side theme
+			case 0x45:
+				sample_start(0, 10, 1);
+				sample_start(1, 11, 1);
+
+				// we'll provision the alternate songs if they're not already
+				if (ff_provision_alt_song == false) {
+					ff_provision_alt_song = true;
+				}
+				
+				break;
+			// bathroom music for bay area
+			case 0x46:
+				sample_start(0, 12, 1);
+				sample_start(1, 13, 1);
+
+				break;
+			// bay area post-bathroom ending/boss / final boss room entrance
+			case 0x47:
+				// play the normal version of the song unless playAlternateSong is true
+				if (ff_provision_alt_song == false) {
+					sample_start(0, 14, 1);
+					sample_start(1, 15, 1);
+				}
+				else {
+					sample_start(0, 36, 1);
+					sample_start(1, 37, 1);
+				}
+				
+				break;
+			// bonus stage music
+			case 0x4c:
+				sample_start(0, 20, 1);
+				sample_start(1, 21, 1);
+
+				break;
+			// industrial music theme
+			case 0x48:
+				sample_start(0, 16, 1);
+				sample_start(1, 17, 1);
+
+				break;
+			// industrial zone elevator ride music
+			case 0x49:
+				sample_start(0, 18, 1);
+				sample_start(1, 19, 1);
+
+				break;
+			// game start ditty
+			case 0x50:
+				sample_start(0, 22, 0);
+				sample_start(1, 23, 0);
+
+				// when the game starts, we'll reset all the alternate songs
+				ff_provision_alt_song = false;
+				ff_play_alternate_song = false;
+				
+				break;
+			// post explosion ditty
+			case 0x51:
+				sample_start(0, 24, 0);
+				sample_start(1, 25, 0);
+
+				break;
+			// opening cinematic song
+			case 0x52:
+				sample_start(0, 46, 0);
+				sample_start(1, 47, 0);
+		
+				break;
+			// continue/dynamite song
+			case 0x53:
+				sample_start(0, 32, 1);
+				sample_start(1, 33, 1);
+				
+				break;
+			// homosexual cheesy ending music
+			case 0x54:
+				sample_start(0, 48, 1);
+				sample_start(1, 49, 1);
+			
+				break;
+			// player select song
+			case 0x55:
+				sample_start(0, 30, 0);
+				sample_start(1, 31, 0);
+				
+				break;
+			// stage end/victory song
+			case 0x57:
+				sample_start(0, 28, 0);
+				sample_start(1, 29, 0);
+				
+				// when we beat a stage after the alternate songs are provisioned, we know that we should be playing the alternate songs
+				if (ff_provision_alt_song == true) {
+					ff_play_alternate_song = true;
+				}
+				
+				break;
+			// final stage clear ditty
+			case 0x58:
+				sample_start(0, 26, 0);
+				sample_start(1, 27, 0);
+								
+				ff_provision_alt_song = false;
+				ff_play_alternate_song = false;
+				
+				break;
+			default:
+				if(ACCESSING_LSB)
+					soundlatch_w(0,data & 0xff);
+
+				// Lets stop the Final Fight sample music.
+				if(data == 0xf0 || data == 0xf2 || data == 0xf7) {
+					int a = 0;
+					
+					for(a = 0; a <= 50; a++) {
+						sample_stop(a);
+					}
+				}
+
+				break;
+		}
+
+		// Determine how we should mix these samples together.
+		if(sample_playing(0) == 0 && sample_playing(1) == 1) { // Right channel only. Lets make it play in both speakers.
+			sample_set_stereo_volume(1, 100, 100);
+		}
+		else if(sample_playing(0) == 1 && sample_playing(1) == 0) { // Left channel only. Lets make it play in both speakers.
+			sample_set_stereo_volume(0, 100, 100);
+		}
+		else if(sample_playing(0) == 1 && sample_playing(1) == 1) { // Both left and right channels. Lets make them play in there respective speakers.
+			sample_set_stereo_volume(0, 100, 0);
+			sample_set_stereo_volume(1, 0, 100);
+		}
+		else if(sample_playing(0) == 0 && sample_playing(1) == 0) { // No sample playing, revert to the default sound.
+			if(ACCESSING_LSB) {
+				soundlatch_w(0,data & 0xff);
+			}
+		}
+	}
+	else {
+		if(ACCESSING_LSB)
+			soundlatch_w(0,data & 0xff);
+	}
 }
 
 static WRITE16_HANDLER( cps1_coinctrl_w )
@@ -3707,6 +3962,19 @@ static MACHINE_DRIVER_START( cps1 )
 	/* sound hardware */
 	MDRV_SOUND_ADD_TAG("2151", YM2151, ym2151_interface)
 	MDRV_SOUND_ADD_TAG("okim", OKIM6295, okim6295_interface_7576)
+MACHINE_DRIVER_END
+
+// For Final Fight.
+static MACHINE_DRIVER_START( ffight_hack )
+	ff_playing_final_fight = true;
+	
+	/* basic machine hardware */
+	MDRV_IMPORT_FROM(cps1)
+
+	// Lets add our Final Fight music sample packs.
+	MDRV_SOUND_ATTRIBUTES(SOUND_SUPPORTS_STEREO)
+	MDRV_SOUND_ADD(SAMPLES, ff_samples)
+	//MDRV_SOUND_ADD(SAMPLES, ff_samplesR)
 MACHINE_DRIVER_END
 
 
@@ -7429,10 +7697,19 @@ GAME( 1989, willowj,  willow,   cps1,     willow,   cps1,     ROT0,   "Capcom", 
 GAME( 1989, willowje, willow,   cps1,     willow,   cps1,     ROT0,   "Capcom", "Willow (Japan, English)" )						// (c) Capcom U.S.A. but Japan "warning"
 GAME( 1989, unsquad,  0,        cps1,     unsquad,  cps1,     ROT0,   "Capcom", "U.N. Squadron (US)" )
 GAME( 1989, area88,   unsquad,  cps1,     unsquad,  cps1,     ROT0,   "Capcom", "Area 88 (Japan)" )
+
+GAME( 1989, ffight,   0,        ffight_hack,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (World)" )
+GAME( 1989, ffightu,  ffight,   ffight_hack,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (US 900112)" )
+GAME( 1989, ffightj,  ffight,   ffight_hack,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (Japan set 1)" )
+GAME( 1989, ffightj1, ffight,   ffight_hack,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (Japan set 2)" )
+
+/*
 GAME( 1989, ffight,   0,        cps1,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (World)" )
 GAME( 1989, ffightu,  ffight,   cps1,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (US 900112)" )
 GAME( 1989, ffightj,  ffight,   cps1,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (Japan set 1)" )
 GAME( 1989, ffightj1, ffight,   cps1,     ffight,   cps1,     ROT0,   "Capcom", "Final Fight (Japan set 2)" )
+*/
+
 GAME( 1990, 1941,     0,        cps1,     1941,     cps1,     ROT270, "Capcom", "1941 - Counter Attack (World)" )
 GAME( 1990, 1941j,    1941,     cps1,     1941,     cps1,     ROT270, "Capcom", "1941 - Counter Attack (Japan)" )
 GAME( 1990, mercs,    0,        cps1,     mercs,    cps1,     ROT270, "Capcom", "Mercs (World 900302)" )						// "ETC"

--- a/src/includes/cps1.h
+++ b/src/includes/cps1.h
@@ -9,6 +9,10 @@ extern size_t cps1_output_size;
 extern const struct Memory_ReadAddress qsound_readmem[];
 extern const struct Memory_WriteAddress qsound_writemem[];
 
+bool	ff_provision_alt_song; // For Final Fight SegaCD music hack.
+bool	ff_play_alternate_song; // For Final Fight SegaCD music hack.
+bool	ff_playing_final_fight; // For Final Fight SegaCD music hack.
+	
 READ16_HANDLER( qsound_sharedram1_r );
 WRITE16_HANDLER( qsound_sharedram1_w );
 

--- a/src/sound/samples.c
+++ b/src/sound/samples.c
@@ -57,6 +57,20 @@ void sample_set_freq(int channel,int freq)
 	mixer_set_sample_frequency(channel + firstchannel,freq);
 }
 
+// Set sample volume by speaker.
+void sample_set_stereo_volume(int channel,int volume_left, int volume_right)
+{
+	if (Machine->sample_rate == 0) return;
+	if (Machine->samples == 0) return;
+	if (channel >= numchannels)
+	{
+		logerror("error: sample_adjust() called with channel = %d, but only %d channels allocated\n",channel,numchannels);
+		return;
+	}
+
+	mixer_set_stereo_volume(channel + firstchannel,volume_left * 100 / 255, volume_right * 100 / 255);
+}
+
 void sample_set_volume(int channel,int volume)
 {
 	if (Machine->sample_rate == 0) return;

--- a/src/sound/samples.h
+++ b/src/sound/samples.h
@@ -14,6 +14,7 @@ struct Samplesinterface
 /* mixer_play_sample() */
 void sample_start(int channel,int samplenum,int loop);
 void sample_set_freq(int channel,int freq);
+void sample_set_stereo_volume(int channel,int volume_left, int volume_right);
 void sample_set_volume(int channel,int volume);
 void sample_stop(int channel);
 int sample_playing(int channel);


### PR DESCRIPTION
ffight.zip samples support with appropriate .wav files  5 Minutes in shows it in action...

https://www.youtube.com/watch?v=dA3YCPefpdU&t=3s

https://github.com/KMFDManic/NESC-SNESC-Modifications/releases/

Thanks to the hard work and dedication and patience of big blue frontend and gpstar!,
we now have support in MAME 2003 for the ability to run the Sega CD Soundtrack along
with Final Fight Arcade Version!  These were originally introduced in a modified
version of MAME 0.185 by big blue frontend, and backported into MAME 2003 by
gpstar!  Both have done an exceptional job!

The Soundtrack can be run a few different ways!  These include 8bit mono, 
8 bit mono-stereo non-usb host, and 8bit mono-stereo mix.  Specific notes 
about each of these are contained at the bottom of this ReadMe!

The files need to be within either MAME_Samples.hmod, within mame2003/samples
OR, via ftp, within /etc/libretro/system/mame2003/samples

They must be contained inside a folder named ffight or a zip named ffight
But, if in folder format, it will take up much more space!  So, it is
best recommended to use .zip format.

You can run without ALL of them.  But, if you decide to remove any...due to
space limitations, remove from 26 and go backwards.  if track02-01.wav and 
track02-02.wav are missing, the system will fall back and default to the 
original music from the game!  Keep that in mind. If installing samples via
Hakchi2, invalid kernel size may trigger if too big!  So, you will have to
either cut some of the files out, or use FTP to transfer them.  USB-HOST
will not have any issue running the Full Soundtrack, since there is no
kernel size limit, other than internal NAND Flash Memory Limit, in installing 
HMODS using hakchi/transfer folder!

The proper file names for the Soundtrack need to be, for each of them:

--8bit mono=

track02-01.wav
track03-01.wav
track04-01.wav
track05-01.wav
track06-01.wav
track07-01.wav
track08-01.wav
track09-01.wav
track10-01.wav
track11-01.wav
track12-01.wav
track13-01.wav
track14-01.wav
track15-01.wav
track16-01.wav
track17-01.wav
track18-01.wav
track19-01.wav
track20-01.wav
track21-01.wav
track22-01.wav
track23-01.wav
track24-01.wav
track25-01.wav
track26-01.wav

8 bit mono-stereo non-usb host

track02-01.wav
track02-02.wav
track03-01.wav
track03-02.wav
track04-01.wav
track04-02.wav
track05-01.wav
track05-02.wav
track06-01.wav
track06-02.wav
track07-01.wav
track07-02.wav
track08-01.wav
track08-02.wav
track09-01.wav
track09-02.wav
track10-01.wav
track10-02.wav
track11-01.wav
track11-02.wav
track12-01.wav
track12-02.wav
track13-01.wav
track13-02.wav
track14-01.wav
track14-02.wav
track15-01.wav
track15-02.wav
track16-01.wav
track16-02.wav
track17-01.wav
track17-02.wav
track18-01.wav
track18-02.wav
track19-01.wav
track19-02.wav
track20-01.wav
track20-02.wav
track21-01.wav
track21-02.wav
track22-01.wav
track22-02.wav
track25-01.wav
track25-02.wav
track26-01.wav
track26-02.wav

8big mono-stereo mix

track02-01.wav
track02-02.wav
track03-01.wav
track03-02.wav
track04-01.wav
track04-02.wav
track05-01.wav
track05-02.wav
track06-01.wav
track06-02.wav
track07-01.wav
track07-02.wav
track08-01.wav
track08-02.wav
track09-01.wav
track09-02.wav
track10-01.wav
track10-02.wav
track11-01.wav
track11-02.wav
track12-01.wav
track12-02.wav
track13-01.wav
track13-02.wav
track14-01.wav
track14-02.wav
track15-01.wav
track15-02.wav
track16-01.wav
track16-02.wav
track17-01.wav
track17-02.wav
track18-01.wav
track18-02.wav
track19-01.wav
track19-02.wav
track20-01.wav
track20-02.wav
track21-01.wav
track21-02.wav
track22-01.wav
track22-02.wav
track23-01.wav
track23-02.wav
track24-01.wav
track24-02.wav
track25-01.wav
track25-02.wav
track26-01.wav
track26-02.wav


Additional Notes from gpstar!

I did up 3 different sound sample files. 8bit mono, 8bit mono/stereo mix
and 8bit mono/stereo mix non-usb mod. The non usb mod I removed 2 tracks
of audio so it can fit on my snes mini better without usb host. (tracks 24
and 25, which are not used at all so they arent needed)

The audio formats that mame2003 will handle is as follows:
8bit mono wav
16 bit mono wav

To recreate a stereo effect of the original music, i extracted the sega cd 
music, opened up each track, split the stereo channels separate, and convert
each channel to a mono track and save them out.  If you take a look inside
the ffight.zip samples you will see track02-01.wav and track02-02.wav. 
01 is the left channel converted to mono, and track02-02.wav is the right 
channel converted to mono. The updated cps code will play back both files 
together, and mixes the track02-01.wav into the left speaker and 
track02-02.wav into the right speaker, thus simulating the original 
stereo track.

I also built in hooks, so if only one of the 2 channels play, it will 
default the playing one into both speakers, it'll be a mono effect but
it'll still work, and is another option for people to cut down on file
size.  So for example if in the ffight.zip, track02-02.wav is missing,
the cps system will play track02-01 into both speakers. Or if 
track02-01.wav is missing, it will play track02-02.wav into both speakers.
